### PR TITLE
Fix GraphQLSyntaxError in mythic.py

### DIFF
--- a/mythic/mythic.py
+++ b/mythic/mythic.py
@@ -190,7 +190,7 @@ async def get_all_active_callbacks(
     """
     query = f"""
     query CurrentCallbacks{{
-        callback(where: {{active: {{_eq: true}}, order_by: {{id: asc}}){{
+        callback(where: {{active: {{_eq: true}}}}, order_by: {{id: asc}}){{
             {custom_return_attributes if custom_return_attributes is not None else '...callback_fragment'}
         }}
     }}


### PR DESCRIPTION
Hi,

After testing this library I gotten the following error:
```
raise GraphQLSyntaxError(
graphql.error.syntax_error.GraphQLSyntaxError: Syntax Error: Expected Name, found ')'.

GraphQL request:3:66
2 |     query CurrentCallbacks{
3 |         callback(where: {active: {_eq: true}, order_by: {id: asc}){
  |                                                                  ^
4 |             ...callback_fragment
```

Looks like there were some brackets missing, after adding them this call works correctly.