### PR TITLE
Fix  TransportQueryError in mythic.py function get_latest_uploaded_file_by_name

### DIFF
--- a/mythic/mythic.py
+++ b/mythic/mythic.py
@@ -1850,7 +1850,7 @@ async def get_latest_uploaded_file_by_name(
     {graphql_queries.file_data_fragment if custom_return_attributes is None else ''}
     """
     output = await mythic_utilities.graphql_post(
-        mythic=mythic, query=file_query,
+            mythic=mythic, query=file_query, variables={"filename": filename}
     )
     return output["filemeta"][0] if output["filemeta"] else {}
 

--- a/mythic/mythic.py
+++ b/mythic/mythic.py
@@ -1850,7 +1850,7 @@ async def get_latest_uploaded_file_by_name(
     {graphql_queries.file_data_fragment if custom_return_attributes is None else ''}
     """
     output = await mythic_utilities.graphql_post(
-            mythic=mythic, query=file_query, variables={"filename": filename}
+        mythic=mythic, query=file_query, variables={"filename": filename}
     )
     return output["filemeta"][0] if output["filemeta"] else {}
 


### PR DESCRIPTION
I ran into the below error and found that while the `get_latest_uploaded_file_by_name` function accepts a filename parameter it is not passed along in the graphql post. This should fix it.
`gpl.transport.exceptions.TransportQueryError: {'message': 'expecting a value for non-nullable variable: "filename"'`